### PR TITLE
Fix North Korea and South Korea names

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -1856,7 +1856,7 @@
 		"independent": "Yes"
 	},
 	{
-		"name": "Korea, North",
+		"name": "North Korea",
 		"a2": "KP",
 		"a3": "PRK",
 		"num": "408",
@@ -1872,7 +1872,7 @@
 		"independent": "Yes"
 	},
 	{
-		"name": "Korea, South",
+		"name": "South Korea",
 		"a2": "KR",
 		"a3": "KOR",
 		"num": "410",


### PR DESCRIPTION
"Korea, North" --> "North Korea"
"Korea, South" --> "South Korea"